### PR TITLE
22 rest endpoint load form

### DIFF
--- a/php/class-minnpost-form-processor-mailchimp-rest.php
+++ b/php/class-minnpost-form-processor-mailchimp-rest.php
@@ -48,20 +48,24 @@ class MinnPost_Form_Processor_MailChimp_Rest {
 	public function register_routes() {
 		$namespace = $this->rest_namespace . $this->rest_version;
 
-		register_rest_route( $namespace, '/mailchimp/user', array(
+		register_rest_route(
+			$namespace,
+			'/mailchimp/user',
 			array(
-				'methods'  => array( WP_REST_Server::CREATABLE, WP_REST_Server::READABLE ),
-				'callback' => array( $this, 'process_rest' ),
-				'args'     => array(
-					'email' => array(
-						//'required'    => true,
-						//'type'        => 'string',
-						'description' => 'The user\'s email address',
-						//'format'      => 'email',
+				array(
+					'methods'  => array( WP_REST_Server::CREATABLE, WP_REST_Server::READABLE ),
+					'callback' => array( $this, 'process_rest' ),
+					'args'     => array(
+						'email' => array(
+							//'required'    => true,
+							//'type'        => 'string',
+							'description' => 'The user\'s email address',
+							//'format'      => 'email',
+						),
 					),
 				),
-			),
-		) );
+			)
+		);
 	}
 
 	/**
@@ -79,8 +83,8 @@ class MinnPost_Form_Processor_MailChimp_Rest {
 
 		switch ( $http_method ) {
 			case 'GET':
-				$user_email            = $request->get_param( 'email' );
-				$reset_user_info       = true;
+				$user_email      = $request->get_param( 'email' );
+				$reset_user_info = true;
 
 				$result = $this->get_data->get_user_info( $shortcode, $resource_type, $resource_id, $user_email, $reset_user_info );
 
@@ -96,7 +100,6 @@ class MinnPost_Form_Processor_MailChimp_Rest {
 				return $user;
 				break;
 			case 'POST':
-
 				// required form data
 				$mailchimp_user_id = $request->get_param( 'mailchimp_user_id' );
 				$status            = $request->get_param( 'mailchimp_status' );

--- a/php/class-minnpost-form-processor-mailchimp-rest.php
+++ b/php/class-minnpost-form-processor-mailchimp-rest.php
@@ -54,7 +54,7 @@ class MinnPost_Form_Processor_MailChimp_Rest {
 			array(
 				array(
 					'methods'  => array( WP_REST_Server::CREATABLE, WP_REST_Server::READABLE ),
-					'callback' => array( $this, 'process_rest' ),
+					'callback' => array( $this, 'process_user_request' ),
 					'args'     => array(
 						'email' => array(
 							//'required'    => true,
@@ -69,11 +69,11 @@ class MinnPost_Form_Processor_MailChimp_Rest {
 	}
 
 	/**
-	* Process the REST API request
+	* Process the REST API request for the user endpoint
 	*
 	* @return $result
 	*/
-	public function process_rest( WP_REST_Request $request ) {
+	public function process_user_request( WP_REST_Request $request ) {
 		$http_method           = $request->get_method();
 		$shortcode             = 'newsletter_form'; // todo: we could make this configurable somehow?
 		$resource_type         = $this->get_data->get_resource_type( $shortcode );


### PR DESCRIPTION
This fixes #22 by creating a REST endpoint that returns form settings based on a shortcode name. This means a client can generate a form that is up to date with the website based on that JSON.